### PR TITLE
Provide gdc builds via make

### DIFF
--- a/makefile
+++ b/makefile
@@ -4,14 +4,18 @@ DMD_COMMON_FLAGS := -dip25 -w $(INCLUDE_PATHS)
 DMD_FLAGS := -O -inline $(DMD_COMMON_FLAGS)
 DMD_TEST_FLAGS := -unittest -g $(DMD_COMMON_FLAGS)
 LDC_FLAGS := -g -w -oq $(INCLUDE_PATHS)
+GDC_FLAGS := -g -w -oq $(INCLUDE_PATHS)
 
-.PHONY: dmd ldc test
+.PHONY: dmd ldc gdc test
 
 dmd: bin/dfmt
 
 ldc: $(SRC)
 	ldc2 $(LDC_FLAGS) $^ -ofbin/dfmt
 	-rm -f *.o
+
+gdc: $(SRC)
+	gdc $(GDC_FLAGS) $^ -obin/dfmt
 
 test: bin/dfmt-test
 	cd tests && ./test.sh

--- a/makefile
+++ b/makefile
@@ -10,12 +10,14 @@ LDC_FLAGS := -g -w -oq $(INCLUDE_PATHS)
 dmd: bin/dfmt
 
 ldc: $(SRC)
-	ldc2 $(LDC_FLAGS) $(SRC) -ofbin/dfmt
+	ldc2 $(LDC_FLAGS) $^ -ofbin/dfmt
 	-rm -f *.o
 
-test:
-	dmd $(DMD_TEST_FLAGS) $(SRC) -ofbin/dfmt
+test: bin/dfmt-test
 	cd tests && ./test.sh
 
+bin/dfmt-test: $(SRC)
+	dmd $(DMD_TEST_FLAGS) $^ -of$@
+
 bin/dfmt: $(SRC)
-	dmd $(DMD_FLAGS) $(SRC) -ofbin/dfmt
+	dmd $(DMD_FLAGS) $^ -of$@

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -12,7 +12,7 @@ do
 		else
 			args=
 		fi
-		../bin/dfmt --brace_style=${braceStyle} ${args} "${source}" > "${braceStyle}/${source}.out"
+		../bin/dfmt-test --brace_style=${braceStyle} ${args} "${source}" > "${braceStyle}/${source}.out"
 		diff -u "${braceStyle}/${source}.ref" "${braceStyle}/${source}.out"
 	done
 done


### PR DESCRIPTION
Fixes #131 

Also includes a commit which avoids rebuilding dfmt on every test run and cleans up the makefile a little.