### PR TITLE
enum can also be used in is() expressions

### DIFF
--- a/src/dfmt/formatter.d
+++ b/src/dfmt/formatter.d
@@ -794,12 +794,16 @@ private:
                 write(" ");
             break;
         case tok!"enum":
-            if (peekBackIs(tok!"identifier"))
-                write(" ");
-            indents.push(tok!"enum");
-            writeToken();
-            if (!currentIs(tok!":"))
-                write(" ");
+            if (peekIs(tok!")") || peekIs(tok!"==")) {
+                writeToken();
+            } else {
+                if (peekBackIs(tok!"identifier"))
+                    write(" ");
+                indents.push(tok!"enum");
+                writeToken();
+                if (!currentIs(tok!":"))
+                    write(" ");
+            }
             break;
         default:
             if (peekBackIs(tok!"identifier"))

--- a/tests/allman/issue0174.d.ref
+++ b/tests/allman/issue0174.d.ref
@@ -1,0 +1,5 @@
+void merge()
+{
+    static if (is(T == enum))
+        *thisN = x;
+}

--- a/tests/issue0174.d
+++ b/tests/issue0174.d
@@ -1,0 +1,5 @@
+void merge()
+{
+    static if (is(T == enum))
+        *thisN = x;
+}

--- a/tests/otbs/issue0174.d.ref
+++ b/tests/otbs/issue0174.d.ref
@@ -1,0 +1,4 @@
+void merge() {
+    static if (is(T == enum))
+        *thisN = x;
+}


### PR DESCRIPTION
fixes #174

I guess is() expressions have more problems, though. I'm not sure how to approach this systematically.

My check for == and ) might not be enough either.