### PR TITLE
dfmt should be buildable under windows

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -5,11 +5,13 @@ set DFLAGS=-g
 set CORE=
 set STD=
 set STDD=
+set STDE=
 
-for %%x in (src\*.d) do set CORE=!CORE! %%x
-for %%x in (libdparse\src\std\*.d) do set STD=!STD! %%x
-for %%x in (libdparse\src\std\d\*.d) do set STDD=!STDD! %%x
+for %%x in (src\dfmt\*.d) do set CORE=!CORE! %%x
+for %%x in (libdparse\src\std\experimental\*.d) do set STD=!STD! %%x
+for %%x in (libdparse\src\dparse\*.d) do set STDD=!STDD! %%x
+for %%x in (libdparse\experimental_allocator\src\std\experimental\allocator\*.d) do set STDE=!STDE! %%x
+for %%x in (libdparse\experimental_allocator\src\std\experimental\allocator\building_blocks\*.d) do set STDE=!STDE! %%x
 
 @echo on
-dmd %CORE% %STD% %STDD% %DFLAGS% -ofbin\dfmt.exe
-
+dmd %CORE% %STD% %STDD% %STDE% %DFLAGS% -ofbin\dfmt.exe


### PR DESCRIPTION
Currently, it's not possible to build `dfmt` under windows os.
This problem occurs due to some source paths modifications, like dfmt has moved to `dfmt` directory inside src, and others related to `dparse`, `experimental_allocator` and so on.

Build fail examiple:
>    c:\D\dfmt>build.bat
>    c:\D\dfmt>dmd    -g -ofbin\dfmt.exe
>    DMD32 D Compiler v2.068.0
>    Copyright (c) 1999-2015 by Digital Mars written by Walter Bright
>    Documentation: http://dlang.org/
>    Config file: C:\D\dmd2\windows\bin\sc.ini
>    (...)