### PR TITLE
Add --assume_filename option

### DIFF
--- a/editor_integration/dfmt-sublime.py
+++ b/editor_integration/dfmt-sublime.py
@@ -1,0 +1,50 @@
+# This file is a minimal dfmt sublime-integration. To install:
+# - Change 'binary' if dfmt is not on the path (see below).
+# - Put this file into your sublime Packages directory, e.g. on Linux:
+#     ~/.config/sublime-text-2/Packages/User/dfmt-sublime.py
+# - Add a key binding (only for D source files):
+#     { "keys": ["ctrl+shift+c"], "command": "dfmt",
+#       "context": [{ "key": "selector", "operator": "equal", "operand": "source.d" }]
+#     }, 
+#
+# With this integration you can press the bound key and dfmt will
+# format the whole file.
+#
+# It operates on the current, potentially unsaved buffer and does not create
+# or save any files. To revert a formatting, just undo.
+#
+# Dfmt will try to search for a .editorconfig file starting from the current file's path. 
+
+from __future__ import print_function
+import sublime
+import sublime_plugin
+import subprocess
+
+# Change this to the full path if dfmt is not on the path.
+# E.g. 'E:\\tools\\bin\\dfmt' (mind the double \\ on Windows)
+binary = 'dfmt'
+
+
+class DfmtCommand(sublime_plugin.TextCommand):
+  def run(self, edit):
+    encoding = self.view.encoding()
+    if encoding == 'Undefined':
+      encoding = 'utf-8'
+    command = [binary, '--assume_filename', str(self.view.file_name())]
+    old_viewport_position = self.view.viewport_position()
+    buf = self.view.substr(sublime.Region(0, self.view.size()))
+    p = subprocess.Popen(command, stdout=subprocess.PIPE,
+                         stderr=subprocess.PIPE, stdin=subprocess.PIPE,
+                         shell=True)
+    output, error = p.communicate(buf.encode(encoding))
+    if error:
+      print(error.decode(encoding))
+      return
+
+    self.view.replace(
+        edit, sublime.Region(0, self.view.size()),
+        output.decode(encoding))
+    self.view.sel().clear()
+    # FIXME: Without the 10ms delay, the viewport sometimes jumps.
+    sublime.set_timeout(lambda: self.view.set_viewport_position(
+      old_viewport_position, False), 10)

--- a/src/dfmt/main.d
+++ b/src/dfmt/main.d
@@ -27,7 +27,8 @@ else
         optConfig.pattern = "*.d";
         bool showHelp;
         bool showVersion;
-
+        string assumeFileName = "dummy.d";
+        
         void handleBooleans(string option, string value)
         {
             import dfmt.editorconfig : OptionalBoolean;
@@ -63,6 +64,7 @@ else
             getopt(args,
                 "version", &showVersion,
                 "align_switch_statements", &handleBooleans,
+                "assume_filename", &assumeFileName,
                 "brace_style", &optConfig.dfmt_brace_style,
                 "end_of_line", &optConfig.end_of_line,
                 "help|h", &showHelp,
@@ -98,7 +100,8 @@ else
 
         args.popFront();
         immutable bool readFromStdin = args.length == 0;
-        immutable string filePath = createFilePath(readFromStdin, readFromStdin ? null : args[0]);
+        immutable string filePath = createFilePath(readFromStdin ? assumeFileName : args[0]);
+
         Config config;
         config.initializeWithDefaults();
         Config fileConfig = getConfigFor!Config(filePath);
@@ -194,6 +197,11 @@ Options:
     --inplace|i         Edit files in place
     --version           Print the version number and then exit
 
+Editor integration options:
+    --assume_filename=<string>
+                        When reading from stdin, dfmt assumes
+                        this filename to look for a style config file.
+
 Formatting Options:
     --align_switch_statements
     --brace_style	`, optionsToString!(typeof(Config.dfmt_brace_style))(), `
@@ -210,14 +218,12 @@ Formatting Options:
     --compact_labeled_statements`);
 }
 
-private string createFilePath(bool readFromStdin, string fileName)
+private string createFilePath(string fileName)
 {
     import std.file : getcwd;
     import std.path : isRooted;
 
     immutable string cwd = getcwd();
-    if (readFromStdin)
-        return buildPath(cwd, "dummy.d");
     if (isRooted(fileName))
         return fileName;
     else


### PR DESCRIPTION
1. Add --assume_filename option to control the search path for the style config file when reading from stdin; needed for editor integration.
2. Add Sublime editor integration python script.

Notes:
1. The assume_filename option is needed because the current working directory (cwd) will generally not be the path of the file in the editor. So when the editor passes the file's contents through stdin, without this option, the correct .editorconfig file for the file in the editor would not be found.
2. This Sublime python script is very similar to the clang-format-sublime.py script from the Clang project. Scripts for other editors can be found in clang's repository in ...\tools\clang-format\ . Note that the scripts will have to be simplified because dfmt currently only supports reformatting the whole file.