### PR TITLE
Fix compilation in Windows for CRuntime_Microsoft

### DIFF
--- a/src/dfmt/main.d
+++ b/src/dfmt/main.d
@@ -113,10 +113,10 @@ else
             // On Windows, set stdout to binary mode (needed for correct EOL writing)
             // See Phobos' stdio.File.rawWrite
             {
-                import std.stdio : fileno, _O_BINARY, setmode;
+                import std.stdio : _fileno, _O_BINARY, _setmode;
 
-                immutable fd = fileno(output.getFP());
-                setmode(fd, _O_BINARY);
+                immutable fd = _fileno(output.getFP());
+                _setmode(fd, _O_BINARY);
                 version (CRuntime_DigitalMars)
                 {
                     import core.atomic : atomicOp;


### PR DESCRIPTION
Use `_setmode` instead of `setmode`, because it works for all supported C runtimes on Windows. See [this](https://github.com/dlang/phobos/blob/v2.071.0/std/stdio.d#L131) and [this]() for more info. I also fixed `_fileno` in order to be consistent with Phobos.
This should fix compilation errors for dmd (`-m32coff` and `-m64`), and ldc2 (`-m32` and `-m64`) (LDC always uses `CRuntime_Microsoft`).

Before:
```
$ git clone https://github.com/Hackerpilot/dfmt
Cloning into 'dfmt'...
remote: Counting objects: 2627, done.
remote: Total 2627 (delta 0), reused 0 (delta 0), pack-reused 2627
Receiving objects: 100% (2627/2627), 521.42 KiB | 450.00 KiB/s, done.
Resolving deltas: 100% (1533/1533), done.
Checking connectivity... done.

$ cd dfmt/

$ git log --pretty=format:'%H %ad' -n 1
90b68b7e57fa80a9195e04a3af94b57091e8bc79 Wed May 4 15:26:31 2016 -0700

$ dmd --version
DMD32 D Compiler v2.072.0-master-7c3ccd8
Copyright (c) 1999-2016 by Digital Mars written by Walter Bright

$ ldc2 --version
LDC - the LLVM D compiler (1.0.0):
  based on DMD v2.070.2 and LLVM 3.9.0git
  built with LDC - the LLVM D compiler (1.0.0)
  Default target: i686-pc-windows-msvc
  Host CPU: ivybridge
  ...

$ dub run --arch=x86 --compiler=dmd -- --help
Performing "debug" build using dmd for x86.
experimental_allocator 2.70.0-b1: target for configuration "library" is up to date.
libdparse 0.7.0-alpha9: target for configuration "library" is up to date.
dfmt 0.5.0-beta3+commit.23.g90b68b7: building configuration "application"...
Linking...
To force a rebuild of up-to-date targets, run again with --force.
Running .\dfmt.exe --help
dfmt 0.5.0
https://github.com/Hackerpilot/dfmt

Options:
    --help, -h          Print this help message
    --inplace, -i       Edit files in place
    --config_dir, -c    Path to directory to load .editconfig file from.
    --version           Print the version number and then exit

Formatting Options:
    --align_switch_statements
    --brace_style               (allman|otbs|stroustrup)
    --end_of_line               (lf|cr|crlf)
    --indent_size
    --indent_style, -t          (tab|space)
    --soft_max_line_length
    --max_line_length
    --outdent_attributes
    --space_after_cast
    --selective_import_space
    --split_operator_at_line_end
    --compact_labeled_statements
    --template_constraint_style
        (conditional_newline_indent|conditional_newline|always_newline|always_newline_indent)

$ dub run --arch=x86 --compiler=ldc2 -- --help
Performing "debug" build using ldc2 for x86.
experimental_allocator 2.70.0-b1: target for configuration "library" is up to date.
libdparse 0.7.0-alpha9: target for configuration "library" is up to date.
dfmt 0.5.0-beta3+commit.23.g90b68b7: building configuration "application"...
src\dfmt\main.d(116): Error: module std.stdio import 'setmode' not found, did you mean function '_setmode'?
src\dfmt\main.d(23): Error: function D main no return exp; or assert(0); at end of function
ldc2 failed with exit code 1.
```

After:
```
$ dub run --arch=x86 --compiler=dmd -- --help
Performing "debug" build using dmd for x86.
experimental_allocator 2.70.0-b1: target for configuration "library" is up to date.
libdparse 0.7.0-alpha9: target for configuration "library" is up to date.
dfmt 0.5.0-beta3+commit.24.ge92b90b: building configuration "application"...
Linking...
To force a rebuild of up-to-date targets, run again with --force.
Running .\dfmt.exe --help
dfmt 0.5.0
https://github.com/Hackerpilot/dfmt

Options:
    --help, -h          Print this help message
    --inplace, -i       Edit files in place
    --config_dir, -c    Path to directory to load .editconfig file from.
    --version           Print the version number and then exit

Formatting Options:
    --align_switch_statements
    --brace_style               (allman|otbs|stroustrup)
    --end_of_line               (lf|cr|crlf)
    --indent_size
    --indent_style, -t          (tab|space)
    --soft_max_line_length
    --max_line_length
    --outdent_attributes
    --space_after_cast
    --selective_import_space
    --split_operator_at_line_end
    --compact_labeled_statements
    --template_constraint_style
        (conditional_newline_indent|conditional_newline|always_newline|always_newline_indent)

$ dub run --arch=x86 --compiler=ldc2 -- --help
Performing "debug" build using ldc2 for x86.
experimental_allocator 2.70.0-b1: target for configuration "library" is up to date.
libdparse 0.7.0-alpha9: target for configuration "library" is up to date.
dfmt 0.5.0-beta3+commit.24.ge92b90b: building configuration "application"...
Using Visual Studio: C:\Program Files (x86)\Microsoft Visual Studio 14.0\
To force a rebuild of up-to-date targets, run again with --force.
Running .\dfmt.exe --help
dfmt 0.5.0
https://github.com/Hackerpilot/dfmt

Options:
    --help, -h          Print this help message
    --inplace, -i       Edit files in place
    --config_dir, -c    Path to directory to load .editconfig file from.
    --version           Print the version number and then exit

Formatting Options:
    --align_switch_statements
    --brace_style               (allman|otbs|stroustrup)
    --end_of_line               (lf|cr|crlf)
    --indent_size
    --indent_style, -t          (tab|space)
    --soft_max_line_length
    --max_line_length
    --outdent_attributes
    --space_after_cast
    --selective_import_space
    --split_operator_at_line_end
    --compact_labeled_statements
    --template_constraint_style
        (conditional_newline_indent|conditional_newline|always_newline|always_newline_indent)
```

After with VS2015 x64 Native Tools Command Prompt:
```
E:\Repos\dfmt>dub run --arch=x86_64 --compiler=dmd -- --help
Performing "debug" build using dmd for x86_64.
experimental_allocator 2.70.0-b1: target for configuration "library" is up to date.
libdparse 0.7.0-alpha9: target for configuration "library" is up to date.
dfmt 0.5.0-beta3+commit.24.ge92b90b: building configuration "application"...
Linking...
To force a rebuild of up-to-date targets, run again with --force.
Running .\dfmt.exe --help
dfmt 0.5.0
https://github.com/Hackerpilot/dfmt

Options:
    --help, -h          Print this help message
    --inplace, -i       Edit files in place
    --config_dir, -c    Path to directory to load .editconfig file from.
    --version           Print the version number and then exit

Formatting Options:
    --align_switch_statements
    --brace_style               (allman|otbs|stroustrup)
    --end_of_line               (lf|cr|crlf)
    --indent_size
    --indent_style, -t          (tab|space)
    --soft_max_line_length
    --max_line_length
    --outdent_attributes
    --space_after_cast
    --selective_import_space
    --split_operator_at_line_end
    --compact_labeled_statements
    --template_constraint_style
        (conditional_newline_indent|conditional_newline|always_newline|always_newline_indent)
```