### PR TITLE
fix #263, Impossible to build under Windows with phobos 2.072

### DIFF
--- a/src/dfmt/main.d
+++ b/src/dfmt/main.d
@@ -113,9 +113,8 @@ else
             // On Windows, set stdout to binary mode (needed for correct EOL writing)
             // See Phobos' stdio.File.rawWrite
             {
-                import std.stdio : _fileno, _O_BINARY, _setmode;
-
-                immutable fd = _fileno(output.getFP());
+                import std.stdio : _O_BINARY;
+                immutable fd = output.fileno;
                 _setmode(fd, _O_BINARY);
                 version (CRuntime_DigitalMars)
                 {
@@ -209,6 +208,19 @@ else
             }
         }
         return 0;
+    }
+}
+
+private version (Windows)
+{
+    version(CRuntime_DigitalMars)
+    {
+        extern(C) int setmode(int, int) nothrow @nogc;
+        alias _setmode = setmode;
+    }
+    else version(CRuntime_Microsoft)
+    {
+        extern(C) int _setmode(int, int) nothrow @nogc;
     }
 }
 


### PR DESCRIPTION
In 2.072.1 the changes that caused the problem are reverted and it seems that there'll gonna be a deprecation process for the symbols used from 2.073. This means that something similar to this PR will be necessary in the next 8-12 months.