### PR TITLE
Fix typo in help message

### DIFF
--- a/src/dfmt/main.d
+++ b/src/dfmt/main.d
@@ -236,7 +236,7 @@ https://github.com/Hackerpilot/dfmt
 Options:
     --help, -h          Print this help message
     --inplace, -i       Edit files in place
-    --config_dir, -c    Path to directory to load .editconfig file from.
+    --config_dir, -c    Path to directory to load .editorconfig file from.
     --version           Print the version number and then exit
 
 Formatting Options:


### PR DESCRIPTION
`.editconfig` should be `.editorconfig` instead.