### PR TITLE
Issue #586 follow-up: Too little indentation if named arguments come after a newline

### DIFF
--- a/src/dfmt/formatter.d
+++ b/src/dfmt/formatter.d
@@ -2330,14 +2330,15 @@ const pure @safe @nogc:
      + Params:
      +   n = Offset to index where search begins. Negative values search backwards.
      + Returns: 
-     +   Index of next token that isn't a comment or an index that is out of bounds.
+     +   Index of next token that isn't a comment or `size_t.max` if no such
+     +   token exists,
      +/
     size_t nextNonComment(int n = 1)
     {
         size_t i = index + n;
         while (n != 0 && i < tokens.length && tokens[i].type == tok!"comment")
             i = n > 0 ? i + 1 : i - 1;
-        return i;
+        return i < tokens.length ? i : size_t.max;
     }
 
     /// Bugs: not unicode correct

--- a/src/dfmt/formatter.d
+++ b/src/dfmt/formatter.d
@@ -1804,6 +1804,12 @@ private:
                     assert(l2 != -1, "Recent '{' is not found despite being in struct initializer");
                     indentLevel = l2 + 1;
                 }
+                else if (canFind(astInformation.namedArgumentColonLocations, tokens[nextNonComment(1)].index))
+                {
+                    immutable l2 = indents.indentToMostRecent(tok!"(");
+                    assert(l2 != -1, "Recent '(' is not found despite being in named function argument");
+                    indentLevel = l2 + 1;
+                }
                 else if ((config.dfmt_compact_labeled_statements == OptionalBoolean.f
                         || !isBlockHeader(2) || peek2Is(tok!"if")) && !indents.topIs(tok!"]"))
                 {
@@ -2314,6 +2320,24 @@ const pure @safe @nogc:
                 + tokens[index - 1].text.representation.count('\n');
 
         return previousTokenEndLineNo < tokens[index].line;
+    }
+
+    /++ 
+     + Get the index of the next token that isn't a comment starting from
+     + current index + n.
+     + If n is negative, searches backwards.
+     + If n = 0, returns index.
+     + Params:
+     +   n = Offset to index where search begins. Negative values search backwards.
+     + Returns: 
+     +   Index of next token that isn't a comment or an index that is out of bounds.
+     +/
+    size_t nextNonComment(int n = 1)
+    {
+        size_t i = index + n;
+        while (n != 0 && i < tokens.length && tokens[i].type == tok!"comment")
+            i = n > 0 ? i + 1 : i - 1;
+        return i;
     }
 
     /// Bugs: not unicode correct

--- a/tests/allman/issue0586.d.ref
+++ b/tests/allman/issue0586.d.ref
@@ -26,3 +26,10 @@ void main()
 
     temp(v1: () { S s = S(i: 5); return s.i; }, v2: 1);
 }
+
+void g()
+{
+    tmp(namedArg1: "abc abc abc abc abc abc abc abc abc abc abc abc abc abc",
+        namedArg2: "abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc",
+        namedArg3: "abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc");
+}

--- a/tests/allman/issue0586_keep_line_breaks.d.ref
+++ b/tests/allman/issue0586_keep_line_breaks.d.ref
@@ -1,0 +1,7 @@
+void test()
+{
+    return Struct(
+        foo: field.foo,
+        bar: field.bar,
+        baz: field.baz);
+}

--- a/tests/issue0586.d
+++ b/tests/issue0586.d
@@ -29,3 +29,10 @@ void main()
 
     temp(v1: () { S s = S(i: 5); return s.i; }, v2: 1);
 }
+
+void g()
+{
+    tmp(namedArg1: "abc abc abc abc abc abc abc abc abc abc abc abc abc abc",
+namedArg2: "abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc",
+namedArg3: "abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc");
+}

--- a/tests/issue0586_keep_line_breaks.args
+++ b/tests/issue0586_keep_line_breaks.args
@@ -1,0 +1,1 @@
+--keep_line_breaks true

--- a/tests/issue0586_keep_line_breaks.d
+++ b/tests/issue0586_keep_line_breaks.d
@@ -1,0 +1,7 @@
+void test()
+{
+    return Struct(
+foo: field.foo,
+bar: field.bar,
+baz: field.baz);
+}

--- a/tests/knr/issue0586.d.ref
+++ b/tests/knr/issue0586.d.ref
@@ -25,3 +25,10 @@ void main()
 
     temp(v1: () { S s = S(i: 5); return s.i; }, v2: 1);
 }
+
+void g()
+{
+    tmp(namedArg1: "abc abc abc abc abc abc abc abc abc abc abc abc abc abc",
+        namedArg2: "abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc",
+        namedArg3: "abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc");
+}

--- a/tests/knr/issue0586_keep_line_breaks.d.ref
+++ b/tests/knr/issue0586_keep_line_breaks.d.ref
@@ -1,0 +1,7 @@
+void test()
+{
+    return Struct(
+        foo: field.foo,
+        bar: field.bar,
+        baz: field.baz);
+}

--- a/tests/otbs/issue0586.d.ref
+++ b/tests/otbs/issue0586.d.ref
@@ -22,3 +22,9 @@ void main() {
 
     temp(v1: () { S s = S(i: 5); return s.i; }, v2: 1);
 }
+
+void g() {
+    tmp(namedArg1: "abc abc abc abc abc abc abc abc abc abc abc abc abc abc",
+        namedArg2: "abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc",
+        namedArg3: "abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc");
+}

--- a/tests/otbs/issue0586_keep_line_breaks.d.ref
+++ b/tests/otbs/issue0586_keep_line_breaks.d.ref
@@ -1,0 +1,6 @@
+void test() {
+    return Struct(
+        foo: field.foo,
+        bar: field.bar,
+        baz: field.baz);
+}


### PR DESCRIPTION
From what I can tell this was the problem: (inside `newline()` function) When setting the new indentLevel, named function arguments didn't have their own case defined in the if-else section when a token pair `"identifier", ":"` is encountered. In the example from the issue thread this selected a case where `indentLevel` gets set to the same as the line with the previous `{` token.

**Fix:** named func args now have their own case which works the same as struct initializer: get indentLevel from previous `tok!"("` and add 1.

Added a helper function to keep the if-condition a bit shorter and lazy. While it can return an out of bounds index, we are inside an if block which guarantees us, that it won't. \
The helper function is repurposed from `peekImplementation`.

Updated existing tests, added test with `--keep_line_breaks true` to match the provided code in issue thread.